### PR TITLE
Fixed bug in random float genome initialization

### DIFF
--- a/genome_float64.go
+++ b/genome_float64.go
@@ -63,7 +63,7 @@ func (g *GAFloatGenome) Switch(x, y int) {
 func (g *GAFloatGenome) Randomize() {
 	l := len(g.Gene)
 	for i := 0; i < l; i++ {
-		g.Gene[i] = rand.Float64()*g.Max + g.Min
+		g.Gene[i] = rand.Float64()*(g.Max-g.Min) + g.Min
 	}
 	g.Reset()
 }


### PR DESCRIPTION
Now GAFloatGenome.Randomize() properly initializes across the correct range (between min and max)
