### PR TITLE
Fix MutatorMulti for > 2 mutators and make code more idiomatic

### DIFF
--- a/mutator_multi.go
+++ b/mutator_multi.go
@@ -9,50 +9,40 @@ Combines several mutators into one, each mutation has equal chance of occuring.
 package ga
 
 import (
-	//"container/vector"
 	"fmt"
 	"math/rand"
 )
 
 type GAMultiMutator struct {
-	//v     *vector.Vector
 	v     []GAMutator
 	stats []int
 }
 
 func NewMultiMutator() *GAMultiMutator {
 	m := new(GAMultiMutator)
-	//m.v = new(vector.Vector)
 	m.v = make([]GAMutator, 0)
 	m.stats = make([]int, 0)
 	return m
 }
 
 func (m GAMultiMutator) Mutate(a GAGenome) GAGenome {
-	//if m.v.Len() == 0 {
 	if len(m.v) == 0 {
 		panic("No mutators added!")
 	}
-	//r := float64(1.0 / float64(m.v.Len()))
 	r := float64(1.0 / float64(len(m.v)))
-	//for i := 0; i < m.v.Len()-1; i++ {
 	for i := 0; i < (len(m.v) - 1); i++ {
 		if rand.Float64() < r {
-			//sm := m.v.At(i).(GAMutator)
 			sm := m.v[i].(GAMutator)
 			m.stats[i]++
 			return sm.Mutate(a)
 		}
 	}
-	//sm := m.v.At(m.v.Len() - 1).(GAMutator)
 	sm := m.v[len(m.v)-1].(GAMutator)
-	//m.stats[m.v.Len()-1]++
 	m.stats[len(m.v)-1]++
 	return sm.Mutate(a)
 }
 
 //Add mutator
-//func (m *GAMultiMutator) Add(a GAMutator) { m.v.Push(a) }
 func (m *GAMultiMutator) Add(a GAMutator) {
 	m.v = append(m.v, a)
 	m.stats = append(m.stats, 0)
@@ -60,9 +50,7 @@ func (m *GAMultiMutator) Add(a GAMutator) {
 func (m GAMultiMutator) String() string { return "GAMultiMutator" }
 func (m *GAMultiMutator) Stats() string {
 	o := "Used "
-	//for i := 0; i < m.v.Len(); i++ {
 	for i := 0; i < len(m.v); i++ {
-		//sm := m.v.At(i).(GAMutator)
 		sm := m.v[i].(GAMutator)
 		o = fmt.Sprintf("%s%s %d times, ", o, sm, m.stats[i])
 	}

--- a/mutator_multi.go
+++ b/mutator_multi.go
@@ -11,6 +11,7 @@ package ga
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 )
 
 type GAMultiMutator struct {
@@ -18,13 +19,16 @@ type GAMultiMutator struct {
 	stats []int
 }
 
+// NewMultiMutator returns a new, empty, multi mutator.
 func NewMultiMutator() *GAMultiMutator {
-	m := new(GAMultiMutator)
-	m.v = make([]GAMutator, 0)
-	m.stats = make([]int, 0)
-	return m
+	return &GAMultiMutator{
+		v:     make([]GAMutator, 0),
+		stats: make([]int, 0),
+	}
 }
 
+// Mutate mutates the genome using one of the mutators added using Add(). Each
+// mutator has equal chance of being chosen.
 func (m *GAMultiMutator) Mutate(a GAGenome) GAGenome {
 	if len(m.v) == 0 {
 		// No mutators, so nothing to do.
@@ -35,17 +39,20 @@ func (m *GAMultiMutator) Mutate(a GAGenome) GAGenome {
 	return m.v[r].Mutate(a)
 }
 
-//Add mutator
+// Add adds a mutator to the MultiMutator.
 func (m *GAMultiMutator) Add(a GAMutator) {
 	m.v = append(m.v, a)
 	m.stats = append(m.stats, 0)
 }
+
+// String returns the name of the mutator.
 func (m GAMultiMutator) String() string { return "GAMultiMutator" }
+
+// Stats() returns a strings with usage details of the individual mutators.
 func (m *GAMultiMutator) Stats() string {
-	o := "Used "
-	for i := 0; i < len(m.v); i++ {
-		sm := m.v[i].(GAMutator)
-		o = fmt.Sprintf("%s%s %d times, ", o, sm, m.stats[i])
+	var o []string
+	for i, sm := range m.v {
+		o = append(o, fmt.Sprintf("%s %d times", sm, m.stats[i]))
 	}
-	return o
+	return "Used " + strings.Join(o, ", ")
 }

--- a/mutator_multi.go
+++ b/mutator_multi.go
@@ -25,22 +25,14 @@ func NewMultiMutator() *GAMultiMutator {
 	return m
 }
 
-func (m GAMultiMutator) Mutate(a GAGenome) GAGenome {
+func (m *GAMultiMutator) Mutate(a GAGenome) GAGenome {
 	if len(m.v) == 0 {
 		// No mutators, so nothing to do.
 		return a.Copy()
 	}
-	r := float64(1.0 / float64(len(m.v)))
-	for i := 0; i < (len(m.v) - 1); i++ {
-		if rand.Float64() < r {
-			sm := m.v[i].(GAMutator)
-			m.stats[i]++
-			return sm.Mutate(a)
-		}
-	}
-	sm := m.v[len(m.v)-1].(GAMutator)
-	m.stats[len(m.v)-1]++
-	return sm.Mutate(a)
+	r := rand.Intn(len(m.v))
+	m.stats[r]++
+	return m.v[r].Mutate(a)
 }
 
 //Add mutator

--- a/mutator_multi.go
+++ b/mutator_multi.go
@@ -27,7 +27,8 @@ func NewMultiMutator() *GAMultiMutator {
 
 func (m GAMultiMutator) Mutate(a GAGenome) GAGenome {
 	if len(m.v) == 0 {
-		panic("No mutators added!")
+		// No mutators, so nothing to do.
+		return a.Copy()
 	}
 	r := float64(1.0 / float64(len(m.v)))
 	for i := 0; i < (len(m.v) - 1); i++ {

--- a/mutator_multi_test.go
+++ b/mutator_multi_test.go
@@ -1,0 +1,81 @@
+package ga
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
+
+// A mutator that does nothing but keeps track of how many times Mutate() hsa been called.
+type testMutator int64
+
+func (m *testMutator) Mutate(_ GAGenome) GAGenome {
+	*m++
+	return nil
+}
+
+func (m *testMutator) String() string {
+	return fmt.Sprintf("%v", *m)
+}
+
+type testMutators []*testMutator
+
+func (tm testMutators) String() string {
+	var out []string
+	for _, m := range tm {
+		out = append(out, m.String())
+	}
+	return strings.Join(out, ", ")
+}
+
+func buildMutatorsAndMutate(nmut int, iters int64) testMutators {
+	mm := NewMultiMutator()
+	var mutators testMutators
+	for i := 0; i < nmut; i++ {
+		tm := testMutator(0)
+		mutators = append(mutators, &tm)
+		mm.Add(&tm)
+	}
+	for i := int64(0); i < iters; i++ {
+		mm.Mutate(nil)
+	}
+	return mutators
+}
+
+// Computes the min/max ratio for the given test mutators.
+func similarity(t *testing.T, mutators testMutators) float64 {
+	min, max := int64(math.MaxInt64), int64(0)
+	for _, m := range mutators {
+		if int64(*m) < min {
+			min = int64(*m)
+		}
+		if int64(*m) > max {
+			max = int64(*m)
+		}
+	}
+	return float64(min+1) / float64(max+1)
+}
+
+// Tests that each mutator in a MultiMutator is called approximately the same
+// number of times.
+func TestMultiMutatorEqualProbability(t *testing.T) {
+	tests := []struct {
+		nmut      int     // Number of mutators.
+		iters     int64   // Number of time Mutate() is called.
+		threshold float64 // Minimum allowed similarity between mutator call count.
+	}{
+		{1, 100000, 1},
+		{2, 100000, 0.95},
+		{10, 100000, 0.90},
+		{100, 1000000, 0.90},
+	}
+	for _, test := range tests {
+		mutators := buildMutatorsAndMutate(test.nmut, test.iters)
+		if got := similarity(t, mutators); got < test.threshold {
+			t.Errorf("Similarity(%v, %v) = %v; want >= %v",
+				test.nmut, test.iters, got, test.threshold)
+			t.Errorf("Mutator counters: [%s]", mutators)
+		}
+	}
+}


### PR DESCRIPTION
Hello, I have fixed an issue with the GAMutatorMulti. The current code does not select the mutators with equal probability except in the case of 2 mutators (and the trivial case of 1 mutator).

I also cleaned up the code a bit, made it more idiomatic and added a test (which I used to test my fix).

Thanks!